### PR TITLE
Added a check to prevent non-CLI calls from failing.

### DIFF
--- a/src/RedisSimpleLock.php
+++ b/src/RedisSimpleLock.php
@@ -33,7 +33,10 @@ class RedisSimpleLock implements Lock
         $this->logger     = $logger ?: new NullLogger;
         $this->id         = mt_rand();
         register_shutdown_function($closure = $this->releaseClosure());
-        pcntl_signal(SIGINT, $closure);
+
+        if (php_sapi_name() === 'cli') {
+            pcntl_signal(SIGINT, $closure);
+        }
     }
 
     public function acquire()

--- a/src/RedisSimpleLockFactory.php
+++ b/src/RedisSimpleLockFactory.php
@@ -12,12 +12,14 @@ class RedisSimpleLockFactory implements TtlFactory
     private $client;
     private $defaultTtl;
     private $logger;
+    private $ignoredSapis;
 
-    public function __construct(Client $client, $defaultTtl = 10000, LoggerInterface $logger = null)
+    public function __construct(Client $client, $defaultTtl = 10000, LoggerInterface $logger = null, array $ignoredSapis = [])
     {
-        $this->client     = $client;
-        $this->defaultTtl = $defaultTtl;
-        $this->logger     = $logger ?: new NullLogger;
+        $this->client       = $client;
+        $this->defaultTtl   = $defaultTtl;
+        $this->logger       = $logger ?: new NullLogger;
+        $this->ignoredSapis = $ignoredSapis;
     }
 
     /**
@@ -30,6 +32,6 @@ class RedisSimpleLockFactory implements TtlFactory
      */
     public function create($identifier, $ttl = null)
     {
-        return new RedisSimpleLock($identifier, $this->client, $ttl ?: $this->defaultTtl, $this->logger);
+        return new RedisSimpleLock($identifier, $this->client, $ttl ?: $this->defaultTtl, $this->logger, $this->ignoredSapis);
     }
 }

--- a/src/RedisSimpleLockFactory.php
+++ b/src/RedisSimpleLockFactory.php
@@ -12,14 +12,14 @@ class RedisSimpleLockFactory implements TtlFactory
     private $client;
     private $defaultTtl;
     private $logger;
-    private $ignoredSapis;
+    private $ignoredSAPIs;
 
-    public function __construct(Client $client, $defaultTtl = 10000, LoggerInterface $logger = null, array $ignoredSapis = [])
+    public function __construct(Client $client, $defaultTtl = 10000, LoggerInterface $logger = null, array $ignoredSAPIs = [])
     {
         $this->client       = $client;
         $this->defaultTtl   = $defaultTtl;
         $this->logger       = $logger ?: new NullLogger;
-        $this->ignoredSapis = $ignoredSapis;
+        $this->ignoredSAPIs = $ignoredSAPIs;
     }
 
     /**
@@ -32,6 +32,6 @@ class RedisSimpleLockFactory implements TtlFactory
      */
     public function create($identifier, $ttl = null)
     {
-        return new RedisSimpleLock($identifier, $this->client, $ttl ?: $this->defaultTtl, $this->logger, $this->ignoredSapis);
+        return new RedisSimpleLock($identifier, $this->client, $ttl ?: $this->defaultTtl, $this->logger, $this->ignoredSAPIs);
     }
 }

--- a/tests/RedisSimpleLockFactoryTest.php
+++ b/tests/RedisSimpleLockFactoryTest.php
@@ -13,7 +13,7 @@ class RedisSimpleLockFactoryTest extends PHPUnit_Framework_TestCase
         $this->redisClient->flushdb();
     }
 
-    public function testCreateIgnoredSapisLock()
+    public function testCreateIgnoredSAPIsLock()
     {
         $factory = new RedisSimpleLockFactory($this->redisClient, 50, null, [php_sapi_name()]);
         $lock = $factory->create('lock identifier');

--- a/tests/RedisSimpleLockFactoryTest.php
+++ b/tests/RedisSimpleLockFactoryTest.php
@@ -19,8 +19,10 @@ class RedisSimpleLockFactoryTest extends PHPUnit_Framework_TestCase
         $lock = $factory->create('lock identifier');
         $this->assertInstanceOf(RedisSimpleLock::class, $lock);
 
-        $handler = pcntl_signal_get_handler(SIGINT);
-        $this->assertEmpty($handler);
+        if (function_exists('pcntl_signal_get_handler')) {
+            $handler = pcntl_signal_get_handler(SIGINT);
+            $this->assertEmpty($handler);
+        }
     }
 
     public function testCreateLock()
@@ -29,7 +31,9 @@ class RedisSimpleLockFactoryTest extends PHPUnit_Framework_TestCase
         $lock = $factory->create('lock identifier');
         $this->assertInstanceOf(RedisSimpleLock::class, $lock);
 
-        $handler = pcntl_signal_get_handler(SIGINT);
-        $this->assertInstanceOf(Closure::class, $handler);
+        if (function_exists('pcntl_signal_get_handler')) {
+            $handler = pcntl_signal_get_handler(SIGINT);
+            $this->assertInstanceOf(Closure::class, $handler);
+        }
     }
 }

--- a/tests/RedisSimpleLockFactoryTest.php
+++ b/tests/RedisSimpleLockFactoryTest.php
@@ -13,10 +13,23 @@ class RedisSimpleLockFactoryTest extends PHPUnit_Framework_TestCase
         $this->redisClient->flushdb();
     }
 
+    public function testCreateIgnoredSapisLock()
+    {
+        $factory = new RedisSimpleLockFactory($this->redisClient, 50, null, [php_sapi_name()]);
+        $lock = $factory->create('lock identifier');
+        $this->assertInstanceOf(RedisSimpleLock::class, $lock);
+
+        $handler = pcntl_signal_get_handler(SIGINT);
+        $this->assertEmpty($handler);
+    }
+
     public function testCreateLock()
     {
         $factory = new RedisSimpleLockFactory($this->redisClient, 50);
         $lock = $factory->create('lock identifier');
         $this->assertInstanceOf(RedisSimpleLock::class, $lock);
+
+        $handler = pcntl_signal_get_handler(SIGINT);
+        $this->assertInstanceOf(Closure::class, $handler);
     }
 }

--- a/tests/RedisSimpleLockTest.php
+++ b/tests/RedisSimpleLockTest.php
@@ -12,6 +12,17 @@ class RedisSimpleLockTest extends PHPUnit_Framework_TestCase
         $this->redisClient->flushdb();
     }
 
+    public function testSAPIIgnore()
+    {
+        $lock1 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null, [php_sapi_name()]);
+        $handler = pcntl_signal_get_handler(SIGINT);
+        $this->assertEmpty($handler);
+
+        $lock2 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null);
+        $handler = pcntl_signal_get_handler(SIGINT);
+        $this->assertInstanceOf(Closure::class, $handler);
+    }
+
     public function testLock()
     {
         $lock1 = new RedisSimpleLock("lock identifier", $this->redisClient, 50);
@@ -72,16 +83,5 @@ class RedisSimpleLockTest extends PHPUnit_Framework_TestCase
 
         // first lock sould have been released
         $lock2->acquire();
-    }
-
-    public function testSAPIIgnore()
-    {
-        $lock1 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null, [php_sapi_name()]);
-        $handler = pcntl_signal_get_handler(SIGINT);
-        $this->assertEmpty($handler);
-
-        $lock2 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null);
-        $handler = pcntl_signal_get_handler(SIGINT);
-        $this->assertInstanceOf(Closure::class, $handler);
     }
 }

--- a/tests/RedisSimpleLockTest.php
+++ b/tests/RedisSimpleLockTest.php
@@ -11,18 +11,7 @@ class RedisSimpleLockTest extends PHPUnit_Framework_TestCase
         $this->redisClient = new \Predis\Client(getenv("REDIS_URI"));
         $this->redisClient->flushdb();
     }
-
-    public function testSAPIIgnore()
-    {
-        $lock1 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null, [php_sapi_name()]);
-        $handler = pcntl_signal_get_handler(SIGINT);
-        $this->assertEmpty($handler);
-
-        $lock2 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null);
-        $handler = pcntl_signal_get_handler(SIGINT);
-        $this->assertInstanceOf(Closure::class, $handler);
-    }
-
+    
     public function testLock()
     {
         $lock1 = new RedisSimpleLock("lock identifier", $this->redisClient, 50);

--- a/tests/RedisSimpleLockTest.php
+++ b/tests/RedisSimpleLockTest.php
@@ -73,4 +73,15 @@ class RedisSimpleLockTest extends PHPUnit_Framework_TestCase
         // first lock sould have been released
         $lock2->acquire();
     }
+
+    public function testSAPIIgnore()
+    {
+        $lock1 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null, [php_sapi_name()]);
+        $handler = pcntl_signal_get_handler(SIGINT);
+        $this->assertEmpty($handler);
+
+        $lock2 = new RedisSimpleLock("lock identifier", $this->redisClient, 50, null);
+        $handler = pcntl_signal_get_handler(SIGINT);
+        $this->assertInstanceOf(Closure::class, $handler);
+    }
 }


### PR DESCRIPTION
When using this package in a script that isn't called through the CLI, there is a big chance that the functions defined in the PCNTL package aren't available, because of obvious security implications.

Because of the fact that the `pcntl_signal` closure is set in the constructor of the `RedisSimpleLock`, this class is unusable when used through different measure than the PHP CLI.

This PR makes sure that the closure is only attached when the CLI is used.